### PR TITLE
feat: allow URLSearchParams to accept Record<string, string> and Iterator<[string, string]>

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -376,7 +376,7 @@ PODS:
   - React-jsinspector (0.72.7)
   - React-logger (0.72.7):
     - glog
-  - react-native-fast-url (0.2.0):
+  - react-native-fast-url (0.3.0):
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
   - react-native-heap-profiler (0.2.2):
@@ -724,7 +724,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: c49502e5d02112247ee4526bc3ccfc891ae3eb9b
   React-jsinspector: 8baadae51f01d867c3921213a25ab78ab4fbcd91
   React-logger: 8edc785c47c8686c7962199a307015e2ce9a0e4f
-  react-native-fast-url: e1d2ad1f293d8fa9edbd584ef4b02724a5a319fb
+  react-native-fast-url: b6ced0288ff8ceec93a0b934b38b9991728501cc
   react-native-heap-profiler: 62d6c489f4b0ddf8f14c38b3e05fce960aa05c2d
   react-native-performance: cef2b618d47b277fb5c3280b81a3aad1e72f2886
   react-native-safe-area-context: 0ee144a6170530ccc37a0fd9388e28d06f516a89

--- a/example/src/screens/Tests/tests/urlSearchParamsTests.ts
+++ b/example/src/screens/Tests/tests/urlSearchParamsTests.ts
@@ -34,6 +34,11 @@ export function registerURLSearchParamsTests() {
         expect(params.get('key1')).to.equal('value1');
         expect(params.get('key2')).to.equal('value2');
       });
+
+      it('should throw for invalid input', () => {
+        // @ts-expect-error
+        expect(() => new URLSearchParams([1])).to.throw();
+      });
     });
 
     describe('Append, Get, and GetAll Tests', () => {

--- a/example/src/screens/Tests/tests/urlSearchParamsTests.ts
+++ b/example/src/screens/Tests/tests/urlSearchParamsTests.ts
@@ -4,6 +4,38 @@ import { URLSearchParams } from 'react-native-fast-url';
 
 export function registerURLSearchParamsTests() {
   describe('URLSearchParams', () => {
+    describe('Constructing the object', () => {
+      it('should allow for constructing without any parameters', () => {
+        const params = new URLSearchParams();
+        expect(params.size).to.equal(0);
+      });
+
+      it('should allow for constructing with the empty string', () => {
+        const params = new URLSearchParams('');
+        expect(params.size).to.equal(0);
+      });
+
+      it('should allow for constructing with a record of key, value strings', () => {
+        const items = { key1: 'value1', key2: 'value2' };
+        const params = new URLSearchParams(items);
+        expect(params.size).to.equal(2);
+        expect(params.get('key1')).to.equal('value1');
+        expect(params.get('key2')).to.equal('value2');
+      });
+
+      it('should allow for constructing with an iterable of key, value strings', () => {
+        function* getSearchParamEntries(): IterableIterator<[string, string]> {
+          yield ['key1', 'value1'];
+          yield ['key2', 'value2'];
+        }
+
+        const params = new URLSearchParams(getSearchParamEntries());
+        expect(params.size).to.equal(2);
+        expect(params.get('key1')).to.equal('value1');
+        expect(params.get('key2')).to.equal('value2');
+      });
+    });
+
     describe('Append, Get, and GetAll Tests', () => {
       it('should append a key-value pair and retrieve it using get', () => {
         const params = new URLSearchParams();
@@ -114,28 +146,6 @@ export function registerURLSearchParamsTests() {
           ['key1', 'value1'],
           ['key2', 'value2'],
         ]);
-      });
-    });
-
-    describe('Set and Size Tests', () => {
-      it('should set a new key-value pair and verify its presence', () => {
-        const params = new URLSearchParams();
-        params.set('key', 'value');
-        expect(params.get('key')).to.equal('value');
-      });
-
-      it('should update an existing key with a new value using set', () => {
-        const params = new URLSearchParams();
-        params.append('key', 'value1');
-        params.set('key', 'value2');
-        expect(params.get('key')).to.equal('value2');
-      });
-
-      it('should correctly reflect the number of unique keys in the size property', () => {
-        const params = new URLSearchParams();
-        params.append('key1', 'value1');
-        params.append('key2', 'value2');
-        expect(params.size).to.equal(2);
       });
     });
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -81,8 +81,48 @@ const FastUrlModule: FastUrlNative = {
 export class URLSearchParams {
   private _urlSearchParams: ReturnType<FastUrlNative['URLSearchParams']>;
 
-  constructor(url?: string) {
-    this._urlSearchParams = FastUrlModule.URLSearchParams(url ?? '');
+  /**
+   * URLSearchParams accepts a variety of different input types:
+   *
+   * - A string, which will be parsed from application/x-www-form-urlencoded format. A leading '?' character is ignored.
+   * - A literal sequence of name-value string pairs, or any object — such as a FormData object — with an iterator that
+   *   produces a sequence of string pairs. Note that File entries will be serialized as [object File] rather than as
+   *   their filename (as they would in an application/x-www-form-urlencoded form).
+   * - A record of string keys and string values. Note that nesting is not supported.
+   *
+   * See https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/URLSearchParams
+   */
+  constructor(
+    init:
+      | string
+      | Record<string, string>
+      | IterableIterator<[string, string]> = ''
+  ) {
+    if (typeof init === 'string') {
+      // If it's a string, pass it directly to the underlying implementation.
+      this._urlSearchParams = FastUrlModule.URLSearchParams(init);
+    } else if (typeof init === 'object' || typeof init === 'function') {
+      // IterableIterator<[string, string]>
+      if (typeof (init as any)[Symbol.iterator] === 'function') {
+        this._urlSearchParams = FastUrlModule.URLSearchParams('');
+
+        for (const pair of init as IterableIterator<[string, string]>) {
+          if (pair.length !== 2) {
+            throw new TypeError('Invalid tuple passed into URLSearchParams');
+          }
+
+          this._urlSearchParams.append(pair[0], pair[1]);
+        }
+      } else {
+        // Record<string, string>
+        this._urlSearchParams = FastUrlModule.URLSearchParams('');
+        for (const [key, value] of Object.entries(init)) {
+          this._urlSearchParams.append(key, value);
+        }
+      }
+    } else {
+      throw new Error('Invalid input passed into URLSearchParams');
+    }
   }
 
   append(key: string, value: string) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -101,24 +101,25 @@ export class URLSearchParams {
     if (typeof init === 'string') {
       // If it's a string, pass it directly to the underlying implementation.
       this._urlSearchParams = FastUrlModule.URLSearchParams(init);
-    } else if (typeof init === 'object' || typeof init === 'function') {
+    } else if (
+      (typeof init === 'object' || typeof init === 'function') &&
+      typeof (init as any)[Symbol.iterator] === 'function'
+    ) {
       // IterableIterator<[string, string]>
-      if (typeof (init as any)[Symbol.iterator] === 'function') {
-        this._urlSearchParams = FastUrlModule.URLSearchParams('');
+      this._urlSearchParams = FastUrlModule.URLSearchParams('');
 
-        for (const pair of init as IterableIterator<[string, string]>) {
-          if (pair.length !== 2) {
-            throw new TypeError('Invalid tuple passed into URLSearchParams');
-          }
+      for (const pair of init as IterableIterator<[string, string]>) {
+        if (pair.length !== 2) {
+          throw new TypeError('Invalid tuple passed into URLSearchParams');
+        }
 
-          this._urlSearchParams.append(pair[0], pair[1]);
-        }
-      } else {
-        // Record<string, string>
-        this._urlSearchParams = FastUrlModule.URLSearchParams('');
-        for (const [key, value] of Object.entries(init)) {
-          this._urlSearchParams.append(key, value);
-        }
+        this._urlSearchParams.append(pair[0], pair[1]);
+      }
+    } else if (typeof init === 'object') {
+      // Record<string, string>
+      this._urlSearchParams = FastUrlModule.URLSearchParams('');
+      for (const [key, value] of Object.entries(init)) {
+        this._urlSearchParams.append(key, value);
       }
     } else {
       throw new Error('Invalid input passed into URLSearchParams');


### PR DESCRIPTION
## What changed

When I tried to use this in my company's project, there were a huge number of fatal errors since we construct URLSearchParams like this:

```ts
const params = new URLSearchParams({ key1: 'value1', key2: 'value2'});
```

Added full spec compliance for the `URLSearchParams` constructor (see [docs](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/URLSearchParams)). Again used node's implementation [here](https://github.com/nodejs/node/blob/64c6d97463c29bade4d6081683dab2cd7cda298d/lib/internal/url.js#L772) as a reference.

## How was it tested?

Tested locally and with unit tests