### PR TITLE
feat: add support for optional base param in URL constructor

### DIFF
--- a/cpp/fast-url.cpp
+++ b/cpp/fast-url.cpp
@@ -25,33 +25,51 @@ namespace fasturl
                         URLSearchParamsHostObject(params)));
         });
 
-        auto URL = HOST_FN(rt, "URL", 1, {
-            // TODO: Technically the spec supports a second optional base parameter
-            // to resolve the url against
-            if (count != 1)
-            {
-                return jsi::Value::undefined();
-            }
-            if (!args[0].isString())
-            {
-                throw jsi::JSError(rt, "Failed to construct 'URL': Invalid URL");
-            }
-            std::string url_raw = args[0].asString(rt).utf8(rt);
-            auto url = ada::parse<ada::url_aggregator>(url_raw);
+        // URL accepts 1 or 2 arguments, with the second argument being an optional "base" string
+        // which we need to resolve the url against
+        auto URL = HOST_FN(rt, "URL", 2, {
+    if (count < 1 || count > 2)
+    {
+        return jsi::Value::undefined();
+    }
+    if (!args[0].isString())
+    {
+        throw jsi::JSError(rt, "Failed to construct 'URL': First argument must be a string");
+    }
+    std::string url_raw = args[0].asString(rt).utf8(rt);
 
-            if (url.has_value())
-            {
-                return jsi::Object::createFromHostObject(
-                    rt, std::make_shared<URLHostObject>(
-                            URLHostObject(url.value())));
-            }
-            else
-            {
-                throw jsi::JSError(rt, "Failed to construct 'URL': Invalid URL");
-            }
+    ada::url_aggregator* base_url_ptr = nullptr;
+    ada::url_aggregator base_url;
 
-            return jsi::Value::undefined();
-        });
+    if (count == 2 && !args[1].isUndefined() && args[1].isString())
+    {
+        std::string base_raw = args[1].asString(rt).utf8(rt);
+        auto base_parse_result = ada::parse<ada::url_aggregator>(base_raw);
+
+        if (!base_parse_result)
+        {
+            throw jsi::JSError(rt, "Failed to construct 'URL': Invalid base URL");
+        }
+
+        base_url = base_parse_result.value();
+        base_url_ptr = &base_url;
+    }
+
+    auto url_parse_result = ada::parse<ada::url_aggregator>(url_raw, base_url_ptr);
+
+    if (url_parse_result)
+    {
+        return jsi::Object::createFromHostObject(
+            rt, std::make_shared<URLHostObject>(
+                    URLHostObject(url_parse_result.value())));
+    }
+    else
+    {
+        throw jsi::JSError(rt, "Failed to construct 'URL': Invalid URL");
+    }
+
+    return jsi::Value::undefined();
+});
 
         jsi::Object module = jsi::Object(rt);
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -376,7 +376,7 @@ PODS:
   - React-jsinspector (0.72.7)
   - React-logger (0.72.7):
     - glog
-  - react-native-fast-url (0.2.0):
+  - react-native-fast-url (0.3.0):
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
   - react-native-heap-profiler (0.2.2):
@@ -724,7 +724,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: c49502e5d02112247ee4526bc3ccfc891ae3eb9b
   React-jsinspector: 8baadae51f01d867c3921213a25ab78ab4fbcd91
   React-logger: 8edc785c47c8686c7962199a307015e2ce9a0e4f
-  react-native-fast-url: e1d2ad1f293d8fa9edbd584ef4b02724a5a319fb
+  react-native-fast-url: b6ced0288ff8ceec93a0b934b38b9991728501cc
   react-native-heap-profiler: 62d6c489f4b0ddf8f14c38b3e05fce960aa05c2d
   react-native-performance: cef2b618d47b277fb5c3280b81a3aad1e72f2886
   react-native-safe-area-context: 0ee144a6170530ccc37a0fd9388e28d06f516a89

--- a/example/src/screens/Tests/tests/urlTests.ts
+++ b/example/src/screens/Tests/tests/urlTests.ts
@@ -36,6 +36,35 @@ export function registerURLTests() {
       });
     });
 
+    describe('URL Constructor with Base Parameter Tests', () => {
+      it('should correctly resolve a relative URL against a base URL', () => {
+        const baseUrl = 'http://www.example.com/base/';
+        const relativeUrl = 'path/page.html';
+        const url = new URL(relativeUrl, baseUrl);
+        expect(url.href).to.equal('http://www.example.com/base/path/page.html');
+      });
+
+      it('should handle a relative URL with a leading slash against a base URL', () => {
+        const baseUrl = 'http://www.example.com/base/';
+        const relativeUrl = '/path/page.html';
+        const url = new URL(relativeUrl, baseUrl);
+        expect(url.href).to.equal('http://www.example.com/path/page.html');
+      });
+
+      it('should throw an error when resolving a relative URL against an invalid base URL', () => {
+        const invalidBaseUrl = 'invalid_base';
+        const relativeUrl = 'path/page.html';
+        expect(() => new URL(relativeUrl, invalidBaseUrl)).to.throw();
+      });
+
+      it('should handle an absolute URL regardless of the base URL', () => {
+        const baseUrl = 'http://www.example.com/base/';
+        const absoluteUrl = 'https://www.another.com/page.html';
+        const url = new URL(absoluteUrl, baseUrl);
+        expect(url.href).to.equal(absoluteUrl);
+      });
+    });
+
     describe('Property Tests', () => {
       const baseUrl =
         'http://username:password@hostname:8080/pathname?search=query#hash';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -57,7 +57,10 @@ type FastUrlNative = {
     values: () => IterableIterator<string>;
     toStirng(): () => string;
   };
-  URL: (url: string) => {
+  URL: (
+    url: string,
+    base?: string
+  ) => {
     href: string;
     origin: string;
     protocol: string;
@@ -178,8 +181,8 @@ export class URL {
     // Do nothing.
   }
 
-  constructor(url: string) {
-    this._url = FastUrlModule.URL(url);
+  constructor(url: string, base?: string) {
+    this._url = FastUrlModule.URL(url, base);
     this._searchParams = new URLSearchParams(this._url.search);
   }
 


### PR DESCRIPTION
URL accepts an optional second `base` parameter that the URL is resolved against. Adds support for this functionality.