### PR TITLE
Extend `URLSearchParams.prototype.set` to support array of strings

### DIFF
--- a/example/src/screens/Tests/tests/urlSearchParamsTests.ts
+++ b/example/src/screens/Tests/tests/urlSearchParamsTests.ts
@@ -138,6 +138,12 @@ export function registerURLSearchParamsTests() {
         expect(params.get('key')).to.equal('value');
       });
 
+      it('should support passing array of strings as a value', () => {
+        const params = new URLSearchParams();
+        params.set('key', ['value1', 'value2']);
+        expect(params.get('key')).to.equal('value1,value2');
+      });
+
       it('should update an existing key with a new value using set', () => {
         const params = new URLSearchParams();
         params.append('key', 'value1');

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -166,7 +166,8 @@ export class URLSearchParams {
     return this._urlSearchParams.keys();
   }
 
-  set(key: string, value: string) {
+  set(key: string, value: string | string[]) {
+    if (Array.isArray(value)) value = value.join(',');
     return this._urlSearchParams.set(key, value);
   }
 


### PR DESCRIPTION
## Summary

This PR extends `URLSearchParams.prototype.set` method to accept Array of strings as its value param.

Fixing #7 