### PR TITLE
fix: Use definedProperty to avoid expo override

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -353,8 +353,19 @@ export class URL {
 }
 
 export function setupPolyfill() {
-  (globalThis as any).URL = URL;
-  (globalThis as any).URLSearchParams = URLSearchParams;
+  Object.defineProperty(globalThis, 'URL', {
+    value: URL,
+    writable: true,
+    enumerable: true,
+    configurable: false,
+  });
+
+  Object.defineProperty(globalThis, 'URLSearchParams', {
+    value: URLSearchParams,
+    writable: true,
+    enumerable: true,
+    configurable: false,
+  });
 }
 
 export default FastUrlModule;


### PR DESCRIPTION
When using expo in a project, it seems that the fast-url polyfill is overridden by expo

https://github.com/expo/expo/blob/5aedff023b75dd2d9eb1aae1cc65e672283c5fdc/packages/expo/src/winter/runtime.native.ts#L14

By using `configurable:false` we can avoid that, it will result in 2 errors in the console, but at least it will work as expected

<img width="721" height="70" alt="image" src="https://github.com/user-attachments/assets/1d312aaa-f172-46c7-98c9-d60f42515669" />


https://github.com/expo/expo/blob/5aedff023b75dd2d9eb1aae1cc65e672283c5fdc/packages/expo/src/winter/installGlobal.ts#L90

