### PR TITLE
feat: Android enable 16kb page alignement

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -21,3 +21,8 @@ find_package(ReactAndroid REQUIRED CONFIG)
 find_package(fbjni REQUIRED CONFIG)
 
 target_link_libraries(${PACKAGE_NAME} fbjni::fbjni ReactAndroid::jsi android)
+
+# Enable Android 16kb native library alignment
+if(CMAKE_ANDROID_NDK_VERSION VERSION_LESS "27")
+    target_link_options(${PACKAGE_NAME} PRIVATE "-Wl,-z,max-page-size=16384")
+endif()

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -69,7 +69,7 @@ android {
     externalNativeBuild {
       cmake {
         cppFlags "-O2 -frtti -fexceptions -Wall -fstack-protector-all -DONANDROID -std=c++1y"
-        arguments '-DANDROID_STL=c++_shared'
+        arguments "-DANDROID_STL=c++_shared", "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
         abiFilters (*reactNativeArchitectures())
       }
     }


### PR DESCRIPTION
https://developer.android.com/guide/practices/page-sizes

> Starting November 1st, 2025, all new apps and updates to existing apps submitted to Google Play and targeting Android 15+ devices must support 16 KB page sizes on 64-bit devices. 

Based on the work done for rn-skia, I applied this on my project and seems to works so far

https://github.com/Shopify/react-native-skia/commit/cc0278fba1f3ef77338bf3f013dbdc471399e808